### PR TITLE
Fix for PHP 5.4 in ExportDocument

### DIFF
--- a/includes/ExportDocument.php
+++ b/includes/ExportDocument.php
@@ -386,7 +386,8 @@ class ExportDocument {
 			if(! is_array($this->getExportDocPosition()))
 				$class->ExportDocPosition = $this->getExportDocPosition()->getExportDocPositionClass_v2();
 			else {
-				foreach($this->getExportDocPosition() as $key => &$exportDoc)
+				$pos = $this->getExportDocPosition();
+				foreach($pos as $key => &$exportDoc)
 					$class->ExportDocPosition[$key] = $exportDoc->getExportDocPositionClass_v2();
 			}
 		}


### PR DESCRIPTION
Sadly we have a client with old PHP Version 5.4. While fixing issues related to this, I also fixed this issue within the DHL-SDK. This just mitigates the PHP error "Cannot create references to elements of a temporary array expression".