### PR TITLE
Hotfix for shipmentorder update (v3), error "missing sequenceNumber"

### DIFF
--- a/includes/BusinessShipment.php
+++ b/includes/BusinessShipment.php
@@ -1871,6 +1871,9 @@ class BusinessShipment extends Version {
 			case 3:
 			default:
 			$data = $this->createShipmentClass_v3($shipmentNumber);
+			
+			//hotfix for shipmentorder update, no array accepted because single operation only
+            $data->ShipmentOrder = $data->ShipmentOrder[0];
 		}
 
 		$response = null;


### PR DESCRIPTION
The update method doesn't accept an array for shipment orders anymore. At the moment the API throws an error because it can't find the sequenceNumber (because this layer includes only the single shipmentorder item).